### PR TITLE
fix: JSDOM 需要传入 url

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -1,5 +1,10 @@
 const JSDOM = require('jsdom').JSDOM;
-const dom = new JSDOM('<!doctype html><html><body></body></html>');
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'https://example.org/',
+  referrer: 'https://example.com/',
+  contentType: 'text/html',
+});
+
 global.window = dom.window;
 global.document = window.document;
 global.navigator = window.navigator;


### PR DESCRIPTION
https://github.com/jsdom/jsdom/compare/892599f92b18ac78684522c3f5278be91e373d21...master
由于 jsdom@11.12.0 支持了 window.localStorage 必须要用
this._document.origin 否则会报错
SecurityErr://github.com/jsdom/jsdom/blob/11.12.0/lib/jsdom/browser/Window.js#L257r